### PR TITLE
Fix errors[0] is undefined, return errors.message instead

### DIFF
--- a/src/DatabaseLayer.js
+++ b/src/DatabaseLayer.js
@@ -29,7 +29,7 @@ export default class DatabaseLayer {
   async executeSql(sql, params = []) {
     return this.executeBulkSql([sql], [params])
       .then(res => res[0])
-      .catch(errors => {throw errors[0]})
+      .catch(errors => {throw (errors.message || '')})
   }
 
   createTable(columnMapping) {


### PR DESCRIPTION
executeBulkSql exception return object { message: ... } that contain SQL error, not an array. So it should return message property instead